### PR TITLE
Firebase Auth UI - no https prefix for auth domain

### DIFF
--- a/src/firemore/config.cljs
+++ b/src/firemore/config.cljs
@@ -44,9 +44,9 @@
 
 (def FIREBASE_DATABASE_URL (https FIREBASE_PROJECT_ID ".firebaseio.com"))
 
-(def FIREBASE_STORAGE_BUCKET (https FIREBASE_PROJECT_ID ".appspot.com"))
+(def FIREBASE_STORAGE_BUCKET (str FIREBASE_PROJECT_ID ".appspot.com"))
 
-(def FIREBASE_AUTH_DOMAIN (https FIREBASE_PROJECT_ID ".firebaseapp.com"))
+(def FIREBASE_AUTH_DOMAIN (str FIREBASE_PROJECT_ID ".firebaseapp.com"))
 
 ;; Constants
 


### PR DESCRIPTION
Firebase Auth UI gets its data from the already initialised `firebase` object. However, it plugs the value from `FIREBASE_AUTH_DOMAIN` to make an URL that's eventually used to make the auth calls. That's why we should not prefix the auth domain with "https://".