### PR TITLE
Macroless transactions (Step 1)

### DIFF
--- a/src/firemore/firestore.cljs
+++ b/src/firemore/firestore.cljs
@@ -146,6 +146,11 @@
         (then (partial closer c)))
        c))))
 
+(defn promise->mchan [fx]
+  (promise->chan
+   (fn [c value] (async/put! c {:success true  :value value}))
+   (fn [c error] (async/put! c {:success false :error error}))))
+
 (def default-options
   {:fb FB})
 

--- a/src/firemore/firestore.cljs
+++ b/src/firemore/firestore.cljs
@@ -118,38 +118,39 @@
     (shared-db fb reference)
     {:js-value (-> value replace-timestamp jsonify)})))
 
-(defn closer [c]
-  (async/close! c))
-
 (defn promise->chan
   ([fx]
    (promise->chan
     fx
-    (fn [c value]
-      (when (some? value)
-        (async/put! c value)))))
+    identity))
   ([fx on-success]
    (promise->chan
     fx
     on-success
-    (fn [c error]
-      (js/console.log error)
-      (async/put! c error))))
+    (fn [error]
+      (ex-info
+       :promise->chan-failure
+       {:error error}))))
   ([fx on-success on-failure]
    (if *transaction*
      (fx)
      (let [c (async/chan)]
        (..
         (fx)
-        (then (partial on-success c))
-        (catch (partial on-failure c))
-        (then (partial closer c)))
+        (then  (fn [value]
+                 (some->> value on-success (async/put! c))))
+        (catch (fn [error]
+                 (when-let [e (on-failure error)]
+                   (js/console.error (pr-str e))
+                   (async/put! c e))))
+        (then  (fn [_]
+                 (async/close! c))))
        c))))
 
 (defn promise->mchan [fx]
   (promise->chan
-   (fn [c value] (async/put! c {:success true  :value value}))
-   (fn [c error] (async/put! c {:success false :error error}))))
+   (fn [value] {:success true  :value value})
+   (fn [error] {:success false :error error})))
 
 (def default-options
   {:fb FB})
@@ -178,9 +179,8 @@
         #(do (.add *transaction* ref js-value)
              (disj-reference reference))
         #(.add ref js-value))
-      (fn [c docRef]
-        (async/put! c {:id (.-id docRef)})
-        (async/close! c))))))
+      (fn [docRef]
+        {:id (.-id docRef)})))))
 
 (defn update-db!
   ([reference value] (update-db! reference value nil))
@@ -245,14 +245,14 @@
      (if query
        (promise->chan
         #(.get (filter-by-query ref query))
-        (fn [c snapshot]
+        (fn [snapshot]
           (let [a (atom [])]
             (.forEach snapshot #(->> % doc-upgrader (swap! a conj)))
-            (async/put! c @a))))
+            @a)))
        (promise->chan
         #(.get ref)
-        (fn [c doc]
-          (->> doc doc-upgrader (async/put! c))))))))
+        (fn [doc]
+          (->> doc doc-upgrader)))))))
 
 (defn snapshot-handler [collection? c snapshot]
   (async/put!

--- a/src/firemore/firestore.cljs
+++ b/src/firemore/firestore.cljs
@@ -122,7 +122,10 @@
   ([fx]
    (promise->chan
     fx
-    (fn [c] (async/close! c))))
+    (fn [c value]
+      (when (some? value)
+        (async/put! c value))
+      (async/close! c))))
   ([fx on-success]
    (promise->chan
     fx

--- a/test/firemore/firestore_test.cljs
+++ b/test/firemore/firestore_test.cljs
@@ -257,7 +257,8 @@
    (async/go
      (let [sf (async/<! (sut/get-db [:cities "SF"]))
            user-id (async/<! (authentication/uid))
-           sf-ref [:users user-id :listen-to-metadata-changes "SF"]
+           uuid (str (random-uuid))
+           sf-ref [:users user-id :listen-to-metadata-changes uuid]
            {:keys [c unsubscribe]} (sut/listen sf-ref {:include-metadata-changes true})]
        (t/testing "Before there was San Francisco, there was nothing."
          (t/is (= config/NO_DOCUMENT (async/<! c))))


### PR DESCRIPTION
This is mostly about simplifying the promise->chan conversion stuff. This is step 1 in terms of getting transactions so that they can be used without a macro.